### PR TITLE
Added colcon build args for local builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,9 @@ RUN apt install cppzmq-dev ros-${ROS_DISTRO}-ros-gz -y --no-install-recommends -
 
 # For distribution of Nav2
 ARG BUILD=true
+ARG COLCON_BUILD_ARGS=""
 RUN if [ "${BUILD}" = "true" ]; then \
-      . /opt/ros/${ROS_DISTRO}/setup.sh && colcon build --symlink-install; \
+      . /opt/ros/${ROS_DISTRO}/setup.sh && colcon build $COLCON_BUILD_ARGS; \
     fi
 
 WORKDIR /root/nav2_ws

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt install cppzmq-dev ros-${ROS_DISTRO}-ros-gz -y --no-install-recommends -
 # For distribution of Nav2
 ARG BUILD=true
 RUN if [ "${BUILD}" = "true" ]; then \
-      . /opt/ros/${ROS_DISTRO}/setup.sh && colcon build; \
+      . /opt/ros/${ROS_DISTRO}/setup.sh && colcon build --symlink-install; \
     fi
 
 WORKDIR /root/nav2_ws

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ If you do NOT want to build Nav2 for distribution with the container (setup for 
 
 Occasionally, may need to update the base and rebuild when it diverges significantly.
 
+Additionaly, if you want to build with customized arguments, you can add your build arguments as in the example `--build-arg COLCON_BUILD_ARGS="--symlink-install"`.
+
 ```
 sudo docker pull osrf/ros:${ROS_DISTRO}-desktop-full
 sudo docker build -t ros-navigation/nav2_docker:local -f Dockerfile .

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you do NOT want to build Nav2 for distribution with the container (setup for 
 
 Occasionally, may need to update the base and rebuild when it diverges significantly.
 
-Additionaly, if you want to build with customized arguments, you can add your build arguments as in the example `--build-arg COLCON_BUILD_ARGS="--symlink-install"`.
+Additionally, if you want to build with customized arguments, you can add your build arguments as in the example `--build-arg COLCON_BUILD_ARGS="--symlink-install"`.
 
 ```
 sudo docker pull osrf/ros:${ROS_DISTRO}-desktop-full


### PR DESCRIPTION
Added --symlink-install arg to colcon build command. Otherwise nav2_common may give build error. Additionaly, it would be great to apply direction inside navigation2 repo : https://github.com/ros-navigation/navigation2/blob/44a69ccde93514ed1a962b7f18cb101ec671d93a/Dockerfile#L119