### PR TITLE
Clone the upstream repositories of navigation2 repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,14 @@ WORKDIR /root/nav2_ws
 RUN mkdir -p ~/nav2_ws/src
 ARG VERSION_TAG=latest
 RUN if [ "${ROS_DISTRO}" = "rolling" ]; then \
-      git clone https://github.com/ros-planning/navigation2.git --branch main ./src/navigation2; \
+      git clone https://github.com/ros-planning/navigation2.git --branch main ./src/navigation2 && \
+      vcs import ./src/ < ./src/navigation2/tools/underlay.repos; \
     elif [ "${VERSION_TAG}" = "latest" ]; then \
-      git clone https://github.com/ros-planning/navigation2.git --branch ${ROS_DISTRO} ./src/navigation2; \
+      git clone https://github.com/ros-planning/navigation2.git --branch ${ROS_DISTRO} ./src/navigation2 && \
+      vcs import ./src/ < ./src/navigation2/tools/underlay.repos; \
     else \
-      git clone https://github.com/ros-planning/navigation2.git --branch ${VERSION_TAG} ./src/navigation2; \
+      git clone https://github.com/ros-planning/navigation2.git --branch ${VERSION_TAG} ./src/navigation2 && \
+      vcs import ./src/ < ./src/navigation2/tools/underlay.repos; \
     fi
 
 RUN rm /etc/ros/rosdep/sources.list.d/20-default.list && rosdep init

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,9 @@ RUN if [ "${ROS_DISTRO}" = "rolling" ]; then \
       git clone https://github.com/ros-planning/navigation2.git --branch main ./src/navigation2 && \
       vcs import ./src/ < ./src/navigation2/tools/underlay.repos; \
     elif [ "${VERSION_TAG}" = "latest" ]; then \
-      git clone https://github.com/ros-planning/navigation2.git --branch ${ROS_DISTRO} ./src/navigation2 && \
-      vcs import ./src/ < ./src/navigation2/tools/underlay.repos; \
+      git clone https://github.com/ros-planning/navigation2.git --branch ${ROS_DISTRO} ./src/navigation2; \
     else \
-      git clone https://github.com/ros-planning/navigation2.git --branch ${VERSION_TAG} ./src/navigation2 && \
-      vcs import ./src/ < ./src/navigation2/tools/underlay.repos; \
+      git clone https://github.com/ros-planning/navigation2.git --branch ${VERSION_TAG} ./src/navigation2; \
     fi
 
 RUN rm /etc/ros/rosdep/sources.list.d/20-default.list && rosdep init


### PR DESCRIPTION
Hello, The problem here is that the dockerfile uses upstream packages like [nav2_minimal_turtlebot_simulation](https://github.com/ros-navigation/navigation2/blob/3763f78d6cf8ed6b4559eb04034891dcf439a41e/tools/underlay.repos#L36) from apt instead of using it from latest version of source code.

Instances for fails: 

I've tried the latest docker image of nav2 rolling and even basic demo doesn't work as expected. I send a goal pose. Planner plans, controller acts and publish to `cmd_vel` topic. However robot doesn't move in simulation owing to the fact that nav2_minimal_turtlebot_simulation is not in latest version in these docker image produced in this CI. So the fixes in accordance with https://github.com/ros-navigation/navigation2/pull/4779 are not applied in these images as long as nav2_minimal_turtlebot_simulation package is not updated in apt.

Note that I couldn't test it in rolling, but tested in jazzy and seems works as expected.