### PR TITLE
Create BASE_IMAGE argument to fix rolling nightly builds

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -40,6 +40,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distro }}
+            BASE_IMAGE=${{ matrix.version.ros_distro == 'rolling' && 'osrf/ros2:nightly' || format('osrf/ros-{0}-desktop-full', matrix.version.ros_distro) }}
             BUILD=true
 
   release_docker:
@@ -158,5 +159,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             ROS_DISTRO=${{ matrix.version.ros_distro }}
+            BASE_IMAGE=${{ format('osrf/ros-{0}-desktop-full', matrix.version.ros_distro) }}
             BUILD=true
             VERSION=${{ steps.get_tag.outputs.highest_tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG ROS_DISTRO=rolling
-FROM osrf/ros:${ROS_DISTRO}-desktop-full
+ARG BASE_IMAGE=osrf/ros:${ROS_DISTRO}-desktop-full
+FROM $BASE_IMAGE
 
 RUN apt update \
     && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends --no-install-suggests \


### PR DESCRIPTION
Rolling nightly builds uses `osrf/ros-rolling-desktop-full` docker image at where ROS2 is installed from apt. I have a case which I have encountered. In this case, geometry msgs was in testing phase, so I had to build geometry msgs locally.

![Screenshot from 2025-01-28 02-13-27](https://github.com/user-attachments/assets/388478bd-7fa3-430a-802f-089c4adb713e)

