### PR TITLE
fix: rename ARM64 Dockerfile stage from 'standard-arm64' to 'standard' to match CI workflow target

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ sudo docker build -f docker/Dockerfile --target devel -t nav2:local-devel .
 sudo docker build -f docker/Dockerfile --target standard -t nav2:local-standard .
 
 # Build the ARM64 standard image (requires buildx)
-sudo docker buildx build --platform linux/arm64 -f docker/Dockerfile.arm64 --target standard-arm64 -t nav2:local-arm64 .
+sudo docker buildx build --platform linux/arm64 -f docker/Dockerfile.arm64 --target standard -t nav2:local-arm64 .
 ```
 
 **Note:** The production image excludes visualization and simulation packages (`nav2_rviz_plugins`, `nav2_bringup`, `nav2_system_tests`, TurtleBot simulation packages) to minimize size. All core navigation functionality (controllers, planners, costmaps, localization, etc.) is included.

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -5,11 +5,11 @@
 #
 # Available Targets:
 #   - builder-arm64: ARM64 builder stage with core Nav2 packages
-#   - standard-arm64: ARM64 runtime image with core Nav2 packages (install/ only)
-#                     Suitable for nav2 development and deployment on ARM64 hardware
+#   - standard: ARM64 runtime image with core Nav2 packages (install/ only)
+#               Suitable for nav2 development and deployment on ARM64 hardware
 #
 # Build Examples:
-#   docker buildx build --platform linux/arm64 -f docker/Dockerfile.arm64 --target standard-arm64 -t nav2:arm64-standard .
+#   docker buildx build --platform linux/arm64 -f docker/Dockerfile.arm64 --target standard -t nav2:arm64-standard .
 
 ARG ROS_DISTRO=rolling
 
@@ -83,12 +83,12 @@ RUN if [ "${BUILD}" = "true" ]; then \
 
 
 # ==============================================================================
-# TARGET: standard-arm64
+# TARGET: standard
 # ==============================================================================
 # ARM64 image with compiled Nav2 binaries for robot development on ARM64 hardware
 # Built on ros-base (GUI/Gazebo excluded - no arm64 apt packages available)
 # Includes: install/ directory (no src/build/log)
-FROM ros:${ROS_DISTRO}-ros-base AS standard-arm64
+FROM ros:${ROS_DISTRO}-ros-base AS standard
 ARG ROS_DISTRO
 
 WORKDIR /root/nav2_ws


### PR DESCRIPTION
## Fix

- Renamed the `standard-arm64` stage to `standard` in `docker/Dockerfile.arm64`
- Updated the local build example in `README.md` to use `--target standard`

The `-arm64` distinction in image tags is already handled by `arch_suffix: "-arm64"` in the workflow, so the stage name does not need the suffix.