### PR TITLE
Install only runtime dependencies for production

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,6 +56,7 @@ RUN if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then \
 
 RUN apt update && apt upgrade -y \
     && rosdep install -y --ignore-src --from-paths src -r \
+       -t build -t buildtool -t build_export -t buildtool_export -t exec \
        --skip-keys "slam_toolbox turtlebot3_gazebo" \
     && rm -rf /var/lib/apt/lists/*
 
@@ -64,7 +65,7 @@ ARG BUILD=true
 ARG COLCON_BUILD_ARGS=""
 RUN if [ "${BUILD}" = "true" ]; then \
       . /opt/ros/${ROS_DISTRO}/setup.sh \
-      && colcon build $COLCON_BUILD_ARGS; \
+      && colcon build --cmake-args -DBUILD_TESTING=OFF $COLCON_BUILD_ARGS; \
     else \
       mkdir -p /root/nav2_ws/install; \
     fi
@@ -103,6 +104,7 @@ RUN if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then \
 
 RUN apt update && apt upgrade -y \
     && rosdep install -y --ignore-src --from-paths src -r \
+       -t build -t buildtool -t build_export -t buildtool_export -t exec \
        --skip-keys "slam_toolbox \
                     turtlebot3_gazebo \
                     rviz2 \
@@ -122,6 +124,7 @@ ARG COLCON_BUILD_ARGS=""
 RUN if [ "${BUILD}" = "true" ]; then \
       . /opt/ros/${ROS_DISTRO}/setup.sh \
       && colcon build \
+     --cmake-args -DBUILD_TESTING=OFF \
          --packages-skip nav2_rviz_plugins \
                          nav2_bringup \
                          nav2_system_tests \
@@ -199,7 +202,7 @@ RUN apt update && \
       rosdep init; \
     fi && rosdep update && \
     rosdep install -y --ignore-src --from-paths src -r --rosdistro ${ROS_DISTRO} \
-    --dependency-types=exec \
+    -t exec \
     --skip-keys "rviz2 \
                  gazebo_ros_pkgs \
                  ros_gz \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -199,6 +199,7 @@ RUN apt update && \
       rosdep init; \
     fi && rosdep update && \
     rosdep install -y --ignore-src --from-paths src -r --rosdistro ${ROS_DISTRO} \
+    --dependency-types=exec \
     --skip-keys "rviz2 \
                  gazebo_ros_pkgs \
                  ros_gz \

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -48,6 +48,7 @@ RUN if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then \
 
 RUN apt-get update \
     && rosdep install -y --ignore-src --from-paths src -r \
+       -t build -t buildtool -t build_export -t buildtool_export -t exec \
        --skip-keys "slam_toolbox \
                     turtlebot3_gazebo \
                     gazebo_ros_pkgs \
@@ -69,6 +70,7 @@ ARG COLCON_BUILD_ARGS=""
 RUN if [ "${BUILD}" = "true" ]; then \
       . /opt/ros/${ROS_DISTRO}/setup.sh \
       && colcon build \
+         --cmake-args -DBUILD_TESTING=OFF \
          --packages-skip nav2_rviz_plugins \
                          nav2_bringup \
                          nav2_system_tests \


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Related to https://github.com/ros-navigation/navigation2/pull/6121  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |N/A |
| Does this PR contain AI-generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points
* Configured `rosdep` to only install runtime dependencies for the production image.