### PR TITLE
Revert skip testing for devel and standard images.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,7 +56,6 @@ RUN if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then \
 
 RUN apt update && apt upgrade -y \
     && rosdep install -y --ignore-src --from-paths src -r \
-       -t build -t buildtool -t build_export -t buildtool_export -t exec \
        --skip-keys "slam_toolbox turtlebot3_gazebo" \
     && rm -rf /var/lib/apt/lists/*
 
@@ -65,7 +64,7 @@ ARG BUILD=true
 ARG COLCON_BUILD_ARGS=""
 RUN if [ "${BUILD}" = "true" ]; then \
       . /opt/ros/${ROS_DISTRO}/setup.sh \
-      && colcon build --cmake-args -DBUILD_TESTING=OFF $COLCON_BUILD_ARGS; \
+      && colcon build $COLCON_BUILD_ARGS; \
     else \
       mkdir -p /root/nav2_ws/install; \
     fi

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -48,7 +48,6 @@ RUN if [ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]; then \
 
 RUN apt-get update \
     && rosdep install -y --ignore-src --from-paths src -r \
-       -t build -t buildtool -t build_export -t buildtool_export -t exec \
        --skip-keys "slam_toolbox \
                     turtlebot3_gazebo \
                     gazebo_ros_pkgs \
@@ -70,7 +69,6 @@ ARG COLCON_BUILD_ARGS=""
 RUN if [ "${BUILD}" = "true" ]; then \
       . /opt/ros/${ROS_DISTRO}/setup.sh \
       && colcon build \
-         --cmake-args -DBUILD_TESTING=OFF \
          --packages-skip nav2_rviz_plugins \
                          nav2_bringup \
                          nav2_system_tests \


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Related to #28  |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on |N/A |
| Does this PR contain AI-generated software? | No |
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points
* Revert the intentional compilation of tests and associated dependencies for the devel and standard images.
* The skipping of the tests is still retained for the production image.