### PR TITLE
Revert "Updating dockerfile to use testing repo for lyrical temporarily (#34)"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,11 +30,6 @@ FROM osrf/ros:${ROS_DISTRO}-desktop-full AS builder-full
 ARG ROS_DISTRO
 ARG VERSION_TAG=latest
 
-# Switch to ROS testing repository for pre-release distributions
-RUN if [ "${ROS_DISTRO}" = "lyrical" ]; then \
-      sed -i 's|packages.ros.org/ros2/|packages.ros.org/ros2-testing/|g' /etc/apt/sources.list.d/* ; \
-    fi
-
 # Install build dependencies
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
     ros-dev-tools \
@@ -81,11 +76,6 @@ RUN if [ "${BUILD}" = "true" ]; then \
 FROM ros:${ROS_DISTRO}-ros-base AS builder-production
 ARG ROS_DISTRO
 ARG VERSION_TAG=latest
-
-# Switch to ROS testing repository for pre-release distributions
-RUN if [ "${ROS_DISTRO}" = "lyrical" ]; then \
-      sed -i 's|packages.ros.org/ros2/|packages.ros.org/ros2-testing/|g' /etc/apt/sources.list.d/* ; \
-    fi
 
 # Install build dependencies
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
@@ -190,11 +180,6 @@ RUN echo 'source "/root/nav2_ws/install/setup.bash"' >> /ros_entrypoint.sh
 # Includes: Core navigation packages only (no GUI/simulation)
 FROM ros:${ROS_DISTRO}-ros-base AS production
 ARG ROS_DISTRO
-
-# Switch to ROS testing repository for pre-release distributions
-RUN if [ "${ROS_DISTRO}" = "lyrical" ]; then \
-      sed -i 's|packages.ros.org/ros2/|packages.ros.org/ros2-testing/|g' /etc/apt/sources.list.d/* ; \
-    fi
 
 WORKDIR /root/nav2_ws
 

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -22,11 +22,6 @@ FROM ros:${ROS_DISTRO}-ros-base AS builder-arm64
 ARG ROS_DISTRO
 ARG VERSION_TAG=latest
 
-# Switch to ROS testing repository for pre-release distributions
-RUN if [ "${ROS_DISTRO}" = "lyrical" ]; then \
-      sed -i 's|packages.ros.org/ros2/|packages.ros.org/ros2-testing/|g' /etc/apt/sources.list.d/* ; \
-    fi
-
 # Install build dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ros-dev-tools \


### PR DESCRIPTION
This reverts PR #34.

Since the Lyrical sync has taken place, we can drop the temporary testing repository and go back to using the official true binaries.

Fixes ros-navigation/navigation2#6297